### PR TITLE
fix fallback URL and format script

### DIFF
--- a/get
+++ b/get
@@ -2,17 +2,17 @@
 
 $ErrorActionPreference = "Stop"
 # Enable TLSv1.2 for compatibility with older clients for current session
-[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $DownloadURL1 = 'https://raw.githubusercontent.com/massgravel/Microsoft-Activation-Scripts/35e044ddc85eed60b27b37c48371bd19cdc678b7/MAS/All-In-One-Version/MAS_AIO-CRC32_8C3AA7E0.cmd'
 $DownloadURL2 = 'https://bitbucket.org/WindowsAddict/microsoft-activation-scripts/raw/35e044ddc85eed60b27b37c48371bd19cdc678b7/MAS/All-In-One-Version/MAS_AIO-CRC32_8C3AA7E0.cmd'
 
 $URLs = @($DownloadURL1, $DownloadURL2)
 $RandomURL1 = Get-Random -InputObject $URLs
-$RandomURL2 = $URLs -ne $RandomURL1
+$RandomURL2 = ($URLs -ne $RandomURL1)[0]
 
 try {
-    $response = Invoke-WebRequest -Uri $RandomURL1 -UseBasicParsing
+	$response = Invoke-WebRequest -Uri $RandomURL1 -UseBasicParsing
 }
 catch {
 	$response = Invoke-WebRequest -Uri $RandomURL2 -UseBasicParsing


### PR DESCRIPTION
type of $RandomURL2 was previously an array, which caused the second download attempt to fail.